### PR TITLE
Handle lists of non dicts in compact_dict

### DIFF
--- a/pysharedutils/dicts.py
+++ b/pysharedutils/dicts.py
@@ -130,20 +130,20 @@ def compact_dict(obj):
     """
     output = {}
     for key, value in six.iteritems(obj):
-        element = None
-        if isinstance(value, collections.Mapping):
-            element = compact_dict(value)
-        elif isinstance(value, list):
-            arr = []
-            for i in value:
-                element = compact_dict(i)
-                arr.append(element)
-            element = arr
-        elif value:
-            element = value
-        if element:
-            output[key] = element
+        value = _compact_dict_value(value)
+        if value:
+            output[key] = value
     return output
+
+
+def _compact_dict_value(value):
+    if isinstance(value, six.string_types):
+        return value
+    elif isinstance(value, collections.Mapping):
+        return compact_dict(value)
+    elif isinstance(value, collections.Iterable):
+        return list(map(_compact_dict_value, value))
+    return value
 
 
 def merge_dicts(*dicts):

--- a/tests/pysharedutils/dicts_tests.py
+++ b/tests/pysharedutils/dicts_tests.py
@@ -66,7 +66,8 @@ class TestCompactDict:
                         'blank': None
                     }
                 }
-            ]
+            ],
+            'roles': ['admin', 'client'],
         }
         expected_output = {
             'username': 'foobar',
@@ -83,7 +84,8 @@ class TestCompactDict:
                         'key': 'value'
                     }
                 }
-            ]
+            ],
+            'roles': ['admin', 'client'],
         }
         output = pysharedutils.compact_dict(data)
         assert_equal(output, expected_output)


### PR DESCRIPTION
If you call `compact_dict` with a dict that contains a list of anything other than a dict, it throws an error:

```python
>>> compact_dict({'roles': ['admin']})
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/Peter/Code/py-shared-utils/tests/pysharedutils/dicts_tests.py", line 90, in test_compact_dict
    output = pysharedutils.compact_dict(data)
  File "/Users/Peter/Code/py-shared-utils/pysharedutils/dicts.py", line 139, in compact_dict
    element = compact_dict(i)
  File "/Users/Peter/Code/py-shared-utils/pysharedutils/dicts.py", line 132, in compact_dict
    for key, value in six.iteritems(obj):
  File "/usr/local/lib/python2.7/site-packages/six.py", line 576, in iteritems
    return iter(d.iteritems(**kw))
AttributeError: 'str' object has no attribute 'iteritems'
```