### PR TITLE
Add support for UpperCamelCase

### DIFF
--- a/pysharedutils/dicts.py
+++ b/pysharedutils/dicts.py
@@ -191,11 +191,11 @@ def snake_case_dict_keys(obj):
     return output
 
 
-def camel_case_dict_keys(obj):
+def camel_case_dict_keys(obj, upper=False):
     """
     :param obj: A dict who's keys has to
         be converted from snake case to camel case.
-
+    :param upper: Whether or not to return UpperCamelCase instead of lowerCamelCase
     Maps the keys of the dict from snake case to camel case.
     Example:
         >>> camel_case_dict_keys({'snake_case': 'snake_case'})
@@ -208,16 +208,16 @@ def camel_case_dict_keys(obj):
             arr = []
             for value in value_list:
                 if isinstance(value, dict):
-                    value = camel_case_dict_keys(value)
+                    value = camel_case_dict_keys(value, upper=upper)
                 arr.append(value)
             element = arr
         elif isinstance(v, dict):
-            element = camel_case_dict_keys(v)
+            element = camel_case_dict_keys(v, upper=upper)
         else:
             element = v
 
         if isinstance(k, six.string_types):
-            key = snake_to_camel_case(k)
+            key = snake_to_camel_case(k, upper=upper)
         else:
             key = k
 

--- a/pysharedutils/strings.py
+++ b/pysharedutils/strings.py
@@ -22,17 +22,24 @@ def camel_to_snake_case(word):
     return word.lower()
 
 
-def snake_to_camel_case(word):
+def snake_to_camel_case(word, upper=False):
     """
     :param word: A string that needs to be converted to camel case.
+    :param upper: Whether or not to return UpperCamelCase instead of lowerCamelCase
 
     Convert words to CamelCase.
     Example:
         >>> snake_to_camel_case('snake_case')
         'snakeCase'
+    Example:
+        >>> snake_to_camel_case('snake_case', upper=True)
+        'SnakeCase'
     """
     word = re.sub(r"(?:^|_)(.)", lambda m: m.group(1).upper(), word)
-    return word[0].lower() + word[1:]
+    if upper:
+        return word
+    else:
+        return word[0].lower() + word[1:]
 
 
 def equals(val1, val2):

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     install_requires=[
-        'six==1.8.0',
-        'pytz==2015.4',
+        'six',
+        'pytz',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/tests/pysharedutils/dicts_tests.py
+++ b/tests/pysharedutils/dicts_tests.py
@@ -205,6 +205,53 @@ class TestCamelCaseDictKeys:
             expected_output
         )
 
+    def test_simple_upper_camel_case_dict_keys(self):
+        output = pysharedutils.camel_case_dict_keys(
+            {'snake_case': 'some value'}, upper=True
+        )
+        assert_equal(
+            output,
+            {'SnakeCase': 'some value'}
+        )
+
+    def test_nested_upper_camel_case_dict_keys(self):
+        obj = {
+            1: 'int key',
+            (1, 2): 'tuple key',
+            'camelCase': '',
+            'user': {
+                'user_name': 'foo',
+                'comments': [
+                    {
+                        'some_coment': 'abc',
+                        'some_nested_dict': {
+                            'camel_case': 'a'
+                        }
+                    }
+                ]
+            }
+        }
+        expected_output = {
+            1: 'int key',
+            (1, 2): 'tuple key',
+            'CamelCase': '',
+            'User': {
+                'UserName': 'foo',
+                'Comments': [
+                    {
+                        'SomeComent': 'abc',
+                        'SomeNestedDict': {
+                            'CamelCase': 'a'
+                        }
+                    }
+                ]
+            }
+        }
+        output = pysharedutils.camel_case_dict_keys(obj, upper=True)
+        assert_equal(
+            output,
+            expected_output
+        )
 
 class TestGetDictProperties:
 

--- a/tests/pysharedutils/strings_tests.py
+++ b/tests/pysharedutils/strings_tests.py
@@ -33,6 +33,9 @@ class TestSnakeCaseToCamel:
         output = pysharedutils.snake_to_camel_case('snake_case')
         assert_equal(output, 'snakeCase')
 
+    def test_snake_to_upper_camel_case(self):
+        output = pysharedutils.snake_to_camel_case('snake_case', upper=True)
+        assert_equal(output, 'SnakeCase')
 
 class TestEquals:
 


### PR DESCRIPTION
Currently, the snake_case conversion methods only allow for a lowerCamelCase result. Added a boolean toggle to allow for UpperCamelCase if desired.

I also noticed setup.py pins specific lib versions. This was causing install conflicts, so I removed the pins. If there's a min version of those dependencies to specify, I can change that to `>=`